### PR TITLE
今日の歩数をDBに渡すAPIの設計＋ミドルウェアの導入

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -4,7 +4,13 @@ function authMiddleware(req, res, next) {
   const token = req.headers.authorization?.split(" ")[1];
   if (!token) return res.status(401).json({ error: "No token" });
   try {
-    const decoded = jwt.verify(token, process.env.SECRET_KEY);
+    const secret = process.env.SECRET_KEY;
+    if (!secret) {
+      return res.status(500).json({ error: "Server misconfiguration" });
+    }
+    const decoded = jwt.verify(token, secret, {
+      algorithms: [process.env.JWT_ALG || "HS256"],
+    });
     req.userId = decoded.id;
     next();
   } catch {

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -1,0 +1,15 @@
+const jwt = require("jsonwebtoken");
+
+function authMiddleware(req, res, next) {
+  const token = req.headers.authorization?.split(" ")[1];
+  if (!token) return res.status(401).json({ error: "No token" });
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET_KEY);
+    req.userId = decoded.id;
+    next();
+  } catch {
+    res.status(401).json({ error: "Invalid token" });
+  }
+}
+
+module.exports = authMiddleware;

--- a/backend/routers/auth.js
+++ b/backend/routers/auth.js
@@ -6,6 +6,7 @@ const jwt = require("jsonwebtoken");
 
 const prisma = new PrismaClient();
 
+//ユーザーの新規登録API
 router.post("/register", async (req, res) => {
   const { name, email, password, age } = req.body;
 
@@ -23,6 +24,7 @@ router.post("/register", async (req, res) => {
   return res.json({ user });
 });
 
+//ユーザーのログインAPI
 router.post("/login", async (req, res) => {
   const { email, password } = req.body;
 

--- a/backend/routers/steps.js
+++ b/backend/routers/steps.js
@@ -21,7 +21,7 @@ router.post("/today", authMiddleware, async (req, res) => {
   try {
     // 既に同じ日付の歩数データがあるかを判定
     const existing = await prisma.stepRecord.findFirst({
-      where: { userId, date: new Date(date) },
+      where: { userId, date: dateObj },
     });
 
     let result;
@@ -34,7 +34,7 @@ router.post("/today", authMiddleware, async (req, res) => {
     } else {
       // 新規作成
       result = await prisma.stepRecord.create({
-        data: { userId, date: new Date(date), steps },
+        data: { userId, date: dateObj, steps },
       });
     }
 

--- a/backend/routers/steps.js
+++ b/backend/routers/steps.js
@@ -9,13 +9,14 @@ const prisma = new PrismaClient();
 router.post("/today", authMiddleware, async (req, res) => {
   // jwtからuserIdを取得
   const userId = req.userId;
-  // dateは "YYYY-MM-DD"で渡す
-  // DBには「その日の0時0分0秒」の日時として保存される
+  // dateは "YYYY-MM-DD"で渡し、DBには「その日の0時0分0秒」の日時として保存される
   const { steps, date } = req.body;
+  const stepsNum = Number(steps);
   const dateObj = new Date(date);
+  const isInvalidDate = Number.isNaN(dateObj.getTime());
 
-  if (!userId || !steps || !dateObj) {
-    return res.status(400).json({ message: "必要なデータがありません" });
+  if (!userId || !stepsNum || !dateObj || isInvalidDate) {
+    return res.status(400).json({ message: "不正な入力です" });
   }
 
   try {
@@ -29,12 +30,12 @@ router.post("/today", authMiddleware, async (req, res) => {
       // 歩数を上書き
       result = await prisma.stepRecord.update({
         where: { id: existing.id },
-        data: { steps },
+        data: { steps: stepsNum },
       });
     } else {
-      // 新規作成
+      // 歩数を新規作成
       result = await prisma.stepRecord.create({
-        data: { userId, date: dateObj, steps },
+        data: { userId, date: dateObj, steps: stepsNum },
       });
     }
 


### PR DESCRIPTION
**今日の歩数をDBに渡すAPIの設計**

↓APIテストはうまくいきました！

<img width="1269" height="606" alt="image" src="https://github.com/user-attachments/assets/87319e30-017b-4fdd-8163-c57e40862b51" />
<img width="1247" height="741" alt="image" src="https://github.com/user-attachments/assets/d11491e6-7209-4672-8625-9b87e94c4a03" />

- ログイン時に取得したJWTをもとにログイン中のユーザーのuserIdを特定して、そのuserIdで今日の歩数をフロントからDBに渡す。
- 今日の歩数がまだ記録されてないなら、データの作成。記録されているなら歩数の上書きを行う


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - JWT-based authentication added to protect API routes and associate requests with authenticated users.
  - User registration and login with password hashing and issuance of 1-day JWT session tokens.
  - Authenticated endpoint to submit or update daily step counts for the signed-in user.

- **Security / Error Handling**
  - Clear 401 responses for missing/invalid tokens; 500 responses for server misconfiguration or other server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->