### PR TITLE
スタイルの改善: BattleCardとStepsPanelの影の設定を統一し、ボーダーを追加

### DIFF
--- a/frontend/src/features/battle/components/battlecord.tsx
+++ b/frontend/src/features/battle/components/battlecord.tsx
@@ -2,7 +2,7 @@ import { View, Text, StyleSheet, Pressable } from "react-native";
 import { Opponent } from "../types";
 
 const PLATE = "#2B3545";
-const SHADOW = "#11161d";
+
 const YELLOW = "#F8D94E";
 const RED = "#F45C4A";
 
@@ -32,16 +32,19 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: PLATE,
     borderRadius: 16,
+    borderWidth: 4,
+    borderColor: '#000',
     padding: 16,
     marginTop: 14,
     flexDirection: "row",
     alignItems: "center",
     gap: 12,
-    shadowColor: SHADOW,
-    shadowOpacity: 0.6,
-    shadowRadius: 6,
-    shadowOffset: { width: 0, height: 3 },
+    shadowColor: '#000',
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    shadowOffset: { width: 4, height: 4 },
     elevation: 5,
+    marginBottom: 16,
   },
   cardTitle: { color: "#E6EDF7", fontSize: 16, marginBottom: 6 },
   cardLabel: { color: "#AAB7C8", fontSize: 14, marginRight: 6 },

--- a/frontend/src/features/battle/components/stepspanel.tsx
+++ b/frontend/src/features/battle/components/stepspanel.tsx
@@ -1,7 +1,6 @@
 import { View, Text, StyleSheet } from "react-native";
 
 const PLATE = "#2B3545";
-const SHADOW = "#11161d";
 const YELLOW = "#F8D94E";
 
 type Props = {
@@ -27,11 +26,13 @@ const styles = StyleSheet.create({
     paddingVertical: 18,
     paddingHorizontal: 16,
     marginBottom: 20,
-    shadowColor: SHADOW,
-    shadowOpacity: 0.7,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
+    shadowColor: '#000',
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    shadowOffset: { width: 5, height: 5 },
     elevation: 6,
+    borderWidth: 5,     
+    borderColor: "black",
   },
   caption: {
     color: "#C9D1E0",


### PR DESCRIPTION
close #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Battle Card visuals with a bold black border, sharper high-contrast shadow, and added bottom spacing for improved separation.
  - Refreshed Steps Panel styling to use a stronger shadow with a distinct offset and a thicker black border for a more defined, tactile appearance.
  - Overall UI polish in the battle components emphasizes clearer hierarchy and increased contrast, improving readability and visual consistency without altering behavior or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->