### PR TITLE
DBの調整(Encountersのバトル済の初期値をfalseに変更)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,6 +52,6 @@ model Encounters {
   recorderUser        User     @relation("EncountersRecords", fields: [RecorderUserId], references: [id])
   recordedUserId      Int
   recordedUser        User     @relation("RecordedEncounters", fields: [recordedUserId], references: [id])
-  done_battle Boolean
+  done_battle Boolean          @default(false)
   createdAt   DateTime @default(now())
 }


### PR DESCRIPTION
EncountersのdoneBattleの初期値をfalseに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New encounters now default to “battle not done,” ensuring consistent status on creation and clearer display across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->