### PR TITLE
すれ違い通信の準備とすれ違った後の人物特定(encount.js)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ const authRoute = require("./routers/auth");
 const stepsRoute = require("./routers/steps");
 const battleRoute = require("./routers/battle");
 const rankingRoute = require("./routers/ranking");
+const encountRoute = require("./routers/encount");
 
 require("dotenv").config();
 
@@ -17,5 +18,6 @@ app.use("/api/auth", authRoute);
 app.use("/api/steps", stepsRoute);
 app.use("/api/battle", battleRoute);
 app.use("/api/ranking", rankingRoute);
+app.use("/api/encount", encountRoute);
 
 app.listen(PORT, () => console.log(`server is running on PORT ${PORT}`));

--- a/backend/routers/encount.js
+++ b/backend/routers/encount.js
@@ -1,0 +1,64 @@
+const router = require("express").Router();
+const { PrismaClient } = require("@prisma/client");
+const authMiddleware = require("../middlewares/authMiddleware");
+
+const prisma = new PrismaClient();
+const EID_EXPIRATION_MS = 60 * 60 * 1000; // 1時間
+
+// Eid_keyの生成と更新を行う
+router.get("/generate", authMiddleware, async (req, res) => {
+    const userId = req.userId;
+    try {
+        const existing = await prisma.eid_key.findFirst({ where: { userId } });
+        const now = new Date();
+        // 生成したeid_keyの消失 or 生成から1時間以上の条件式
+        if (!existing || now - existing.createdAt > EID_EXPIRATION_MS) {
+            // 新しいeid_keyを作成（Prismaのuuid生成に任せる）
+            const newEid = await prisma.eid_key.create({
+                data: { userId }
+            });
+            return res.json({ eid: newEid.eid });
+        }
+        return res.json({ eid: existing.eid });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ error: "EID生成エラー" });
+    }
+});
+
+// すれ違いを記録
+router.post("/Recording", authMiddleware, async (req, res) => {
+    // "記録する人" -> "recorder"
+    const recorderUserId = req.userId;
+    const { eid } = req.body;
+    if (!eid) return res.status(400).json({ error: "eidが必要です" });
+
+    try {
+        const eidKey = await prisma.eid_key.findUnique({ where: { eid } });
+        if (!eidKey) return res.status(404).json({ error: "相手のeidが見つかりません" });
+
+        // 有効期限チェック
+        if (new Date() - eidKey.createdAt > EID_EXPIRATION_MS) {
+            return res.status(400).json({ error: "eidの有効期限が切れています" });
+        }
+
+        // 自分自身との遭遇は記録しない
+        if (recorderUserId === eidKey.userId) {
+            return res.status(400).json({ error: "自分自身は記録できません" });
+        }
+
+        const encounter = await prisma.encounters.create({
+            data: {
+                recorderUserId,
+                recordedUserId: eidKey.userId,
+                done_battle: false
+            }
+        });
+        return res.status(201).json(encounter);
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ error: "遭遇記録エラー" });
+    }
+});
+
+module.exports = router;


### PR DESCRIPTION
bluetooth周りで、バックエンドで作るべきと判断したAPIを用意しました。想定していた仕様と違った場合は作り直しますので確認願います。

### 仕様
- encount.js
  - /generate
    - アプリ側が通信したい！( or 通信する！)と判断した時に、これを起動して**自身のuserIdをこの関数に投げる**
    - **eid(_key)**という非常に堅牢な文字列を生成してDBに格納 && **Frontに返す**
    - セキュリティ面の関係で、**1時間に一回**、**eidを再生成する**ようにしている
      - さっき確認したらフロント側で1時間に一回動かさないと厳しいそうです
  - /Recording
    - (前提)Frontはbluetooth通信をするときにeid_keyを発する(はず)。他のアプリユーザを見つけたらそのユーザが発しているeidを取得する
    - 取得した**eid**をこの関数に投げることで、**UserテーブルのEncountにすれ違ったユーザが追加される**
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added new authenticated API group at /api/encount.
  - GET /api/encount/generate: fetches or creates a time-limited (1 hour) encounter ID tied to your account.
  - POST /api/encount/Recording: records an encounter with another user via their encounter ID; self-recording is blocked.
  - Robust input validation, expiration checks, and consistent Japanese error messages with appropriate status codes to guide clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->